### PR TITLE
Fix crash if IP6 address is specified.

### DIFF
--- a/src/nm-wireguard-service.c
+++ b/src/nm-wireguard-service.c
@@ -423,7 +423,7 @@ set_config(NMVpnServicePlugin *plugin, NMConnection *connection)
 	if(setting){
 		val = ip6_to_gvariant(setting);
 		if(val){
-			g_variant_builder_add(&ip6builder, "{sv}", NM_VPN_PLUGIN_IP6_CONFIG_ADDRESS, setting);
+			g_variant_builder_add(&ip6builder, "{sv}", NM_VPN_PLUGIN_IP6_CONFIG_ADDRESS, val);
 			has_ip6 = TRUE;
 		}
 	}


### PR DESCRIPTION
If an IP6 address is specified, the service crashes after setting up the VPN link.