### PR TITLE
Change Listen Port from a required parameter to an optional parameter

### DIFF
--- a/properties/nm-wireguard-editor.c
+++ b/properties/nm-wireguard-editor.c
@@ -127,6 +127,11 @@ check_peer_public_key(const char *str){
 static gboolean
 check_interface_listen_port(const char *str)
 {
+	// Listen port is not a required field according to man wg
+	if(is_empty(str)){
+		return TRUE;
+	}
+
 	if(!g_ascii_string_to_unsigned(str, 10, 0, 65535, NULL, NULL)){
 		return FALSE;
 	}

--- a/shared/import-export.c
+++ b/shared/import-export.c
@@ -1029,13 +1029,6 @@ handle_line_error:
 		goto out_error;
 	}
 
-	if(!have_listen_port){
-		g_set_error_literal(error, NMV_EDITOR_PLUGIN_ERROR, NMV_EDITOR_PLUGIN_ERROR_FAILED,
-							"The file to import wasn't a valid Wireguard configuration (no local listen port)");
-
-		goto out_error;
-	}
-
 	if(!have_ip4_addr && !have_ip6_addr){
 		g_set_error_literal(error, NMV_EDITOR_PLUGIN_ERROR, NMV_EDITOR_PLUGIN_ERROR_FAILED,
 							"The file to import wasn't a valid Wireguard configuration (no local IPv4 or IPv6 addresses)");
@@ -1152,14 +1145,6 @@ create_config_string (NMConnection *connection, GError **error)
 		return NULL;
 	}
 
-	if(!listen_port){
-		g_set_error_literal(error,
-							NMV_EDITOR_PLUGIN_ERROR,
-							NMV_EDITOR_PLUGIN_ERROR_FILE_NOT_VPN,
-							"Connection was incomplete (missing local listen port)");
-		return NULL;
-	}
-
 	if(!private_key){
 		g_set_error_literal(error,
 							NMV_EDITOR_PLUGIN_ERROR,
@@ -1206,7 +1191,10 @@ create_config_string (NMConnection *connection, GError **error)
 	args_write_line(f, value);
 	g_free(value);
 
-	args_write_line(f, NMV_WG_TAG_LISTEN_PORT, "=", listen_port);
+	if(listen_port){
+		args_write_line(f, NMV_WG_TAG_LISTEN_PORT, "=", listen_port);
+	}
+
 
 	if(post_up){
 		args_write_line(f, NMV_WG_TAG_POST_UP, "=", post_up);


### PR DESCRIPTION
As mentioned in Issue #7 the 'wg' man page specifies that a random port will be selected if no Listen Port is supplied so this change makes the Listen Port optional.