### PR TITLE
Nm gtk devel missing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -194,14 +194,12 @@ properties_libnm_wireguard_properties_core_la_CPPFLAGS = \
 	-DNETWORKMANAGER_COMPILATION=NM_NETWORKMANAGER_COMPILATION_LIB \
 	$(properties_cppflags) \
 	$(GTK_CFLAGS) \
-	$(LIBNM_GLIB_CFLAGS) \
-	$(LIBNM_GTK_CFLAGS)
+	$(LIBNM_GLIB_CFLAGS)
 
 properties_libnm_wireguard_properties_core_la_LIBADD = \
 	$(GLIB_LIBS) \
 	$(GTK_LIBS) \
-	$(LIBNM_GLIB_LIBS) \
-	$(LIBNM_GTK_LIBS)
+	$(LIBNM_GLIB_LIBS)
 
 
 if WITH_LIBNM_GLIB

--- a/configure.ac
+++ b/configure.ac
@@ -102,7 +102,6 @@ if test x"$with_gnome" != xno; then
 	PKG_CHECK_MODULES(LIBSECRET, libsecret-1 >= 0.18)
 
 	if test x"$with_libnm_glib" != xno; then
-		PKG_CHECK_MODULES(LIBNM_GTK, libnm-gtk >= 1.7.0)
 		PKG_CHECK_MODULES(LIBNM_GLIB,
 			NetworkManager >= 1.7.0
 			libnm-util >= 1.7.0

--- a/shared/nm-default.h
+++ b/shared/nm-default.h
@@ -106,18 +106,4 @@
 
 #endif /* NM_VPN_OLD */
 
-/*****************************************************************************/
-
-#if (NETWORKMANAGER_COMPILATION) & NM_NETWORKMANAGER_COMPILATION_LIB_EDITOR
-
-#ifdef NM_VPN_OLD
-#include <nm-ui-utils.h>
-#else /* NM_VPN_OLD */
-#include <nma-ui-utils.h>
-#endif /* NM_VPN_OLD */
-
-#endif /* NM_NETWORKMANAGER_COMPILATION_LIB_EDITOR */
-
-/*****************************************************************************/
-
 #endif /* __NM_DEFAULT_H__ */


### PR DESCRIPTION
Per Issue #9 and Issue #19, lib-nm-gtk is being removed from the main Network Manager build. This pull request removes the dependency on this library (which apparently wasn't really being used anyway).

This compiled on both openSuse Tumbleweed (which removed the lib) and Leap (which is older and still includes the lib) but I would recommend testing it on any other distros you have available before merging it to the main line.