### PR TITLE
Fix DNS Settings

### DIFF
--- a/shared/import-export.c
+++ b/shared/import-export.c
@@ -1242,6 +1242,10 @@ create_config_string (NMConnection *connection, GError **error)
 		args_write_line(f, NMV_WG_TAG_POST_DOWN, "=", post_down);
 	}
 
+	if (dns){
+		args_write_line(f, NMV_WG_TAG_DNS, "=", dns);
+	}
+
 	args_write_line(f, NMV_WG_TAG_PEER);
 	args_write_line(f, NMV_WG_TAG_PUBLIC_KEY, "=", public_key);
 	args_write_line(f, NMV_WG_TAG_ENDPOINT, "=", endpoint);


### PR DESCRIPTION
Although there are DNS settings available in the networkmanager dialogs, they were not being written to the file that `wg-quick` uses to set up the connection and were therefore not being applied. This tiny patch corrects this.

Fixes #24 