### PR TITLE
Delete extra DNS write to config file.

### DIFF
--- a/shared/import-export.c
+++ b/shared/import-export.c
@@ -1244,10 +1244,6 @@ create_config_string (NMConnection *connection, GError **error)
 		args_write_line(f, NMV_WG_TAG_POST_DOWN, "=", post_down);
 	}
 
-	if (dns){
-		args_write_line(f, NMV_WG_TAG_DNS, "=", dns);
-	}
-
 	args_write_line(f, NMV_WG_TAG_PEER);
 	args_write_line(f, NMV_WG_TAG_PUBLIC_KEY, "=", public_key);
 	args_write_line(f, NMV_WG_TAG_ENDPOINT, "=", endpoint);


### PR DESCRIPTION
This was entirely my fault. 
Somehow the lines:
	if(dns){
		args_write_line(f,NMV_WG_TAG_DNS, "=", dns);
	}
got left out of create_config_string in import-export.c when I pushed the original DNS fix in pull request #18 even though I had it in my local copy. This was corrected by Queuecumber in pull request #25 but it was also inadvertently "corrected" when I did pull request #22 which was based off of my local copy.

Unfortunately the two pull requests added the lines in slightly different locations so it ended up with two copies of the lines in the function so this pull request removes one of them. Sorry about this.