### PR TITLE
Makefile.am: store appdata to /usr/share/metainfo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -266,7 +266,7 @@ uninstall-hook:
 	 rm -f $(DESTDIR)$(sysconfdir)/NetworkManager/VPN/nm-wireguard-service.name
 endif
 
-appdatadir = $(datadir)/appdata
+appdatadir = $(datadir)/metainfo
 appdata_files = $(appdata_in_files:.xml.in=.xml)
 if WITH_GNOME
 appdata_DATA = $(appdata_files)


### PR DESCRIPTION
The path '/usr/share/appdata' is deprecated and
should be changed to '/usr/share/metainfo'.

See section: 2.1.2. Filesystem locations
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html

Signed-off-by: Conrad Kostecki <conrad@kostecki.com>